### PR TITLE
Add `configOverride` parameter to `getSchema`

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,11 +1,11 @@
 import { CstParser } from 'chevrotain';
-import getConfig from './getConfig';
+import { PrismaAstConfig } from './getConfig';
 import * as lexer from './lexer';
 
 type ComponentType = 'datasource' | 'generator' | 'model' | 'view' | 'enum';
 export class PrismaParser extends CstParser {
-  constructor() {
-    super(lexer.multiModeTokens, getConfig().parser);
+  constructor(config: PrismaAstConfig) {
+    super(lexer.multiModeTokens, config.parser);
     this.performSelfAnalysis();
   }
 
@@ -228,5 +228,3 @@ export class PrismaParser extends CstParser {
     });
   });
 }
-
-export const parser = new PrismaParser();

--- a/src/schemaUtils.ts
+++ b/src/schemaUtils.ts
@@ -1,5 +1,4 @@
 import type { CstNode, IToken } from 'chevrotain';
-import getConfig from './getConfig';
 import * as schema from './getSchema';
 
 const schemaObjects = ['model', 'view'];
@@ -28,9 +27,6 @@ export function appendLocationData<T extends Record<string, unknown>>(
   data: T,
   ...tokens: IToken[]
 ): T {
-  const { parser } = getConfig();
-  if (parser.nodeLocationTracking === 'none') return data;
-
   const location = tokens.reduce((memo, token) => {
     if (!token) return memo;
 

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,183 +1,226 @@
 import { CstNode, IToken } from '@chevrotain/types';
-import { parser } from './parser';
 import * as Types from './getSchema';
+
 import { appendLocationData, isToken } from './schemaUtils';
+import { PrismaAstConfig } from './getConfig';
+import { PrismaParser } from './parser';
+import { ICstVisitor } from 'chevrotain';
 
-const BasePrismaVisitor = parser.getBaseCstVisitorConstructorWithDefaults();
-export class PrismaVisitor extends BasePrismaVisitor {
-  constructor() {
-    super();
-    this.validateVisitor();
-  }
+type Class<T> = new (...args: any[]) => T;
 
-  schema(ctx: CstNode & { list: CstNode[] }): Types.Schema {
-    const list = ctx.list?.map((item) => this.visit([item])) || [];
-    return { type: 'schema', list };
-  }
-
-  component(
-    ctx: CstNode & {
-      type: [IToken];
-      componentName: [IToken];
-      block: [CstNode];
+export const VisitorClassFactory = (
+  parser: PrismaParser
+): Class<ICstVisitor<any, any>> => {
+  const BasePrismaVisitor = parser.getBaseCstVisitorConstructorWithDefaults();
+  return class PrismaVisitor extends BasePrismaVisitor {
+    constructor(private readonly config: PrismaAstConfig) {
+      super();
+      this.validateVisitor();
     }
-  ): Types.Block {
-    const [type] = ctx.type;
-    const [name] = ctx.componentName;
-    const list = this.visit(ctx.block);
 
-    const data = (() => {
-      switch (type.image) {
-        case 'datasource':
-          return {
-            type: 'datasource',
-            name: name.image,
-            assignments: list,
-          } as const;
-        case 'generator':
-          return {
-            type: 'generator',
-            name: name.image,
-            assignments: list,
-          } as const;
-        case 'model':
-          return { type: 'model', name: name.image, properties: list } as const;
-        case 'view':
-          return { type: 'view', name: name.image, properties: list } as const;
-        case 'enum':
-          return { type: 'enum', name: name.image, enumerators: list } as const;
-        default:
-          throw new Error(`Unexpected block type: ${type}`);
+    schema(ctx: CstNode & { list: CstNode[] }): Types.Schema {
+      const list = ctx.list?.map((item) => this.visit([item])) || [];
+      return { type: 'schema', list };
+    }
+
+    component(
+      ctx: CstNode & {
+        type: [IToken];
+        componentName: [IToken];
+        block: [CstNode];
       }
-    })();
+    ): Types.Block {
+      const [type] = ctx.type;
+      const [name] = ctx.componentName;
+      const list = this.visit(ctx.block);
 
-    return appendLocationData(data, type, name);
-  }
+      const data = (() => {
+        switch (type.image) {
+          case 'datasource':
+            return {
+              type: 'datasource',
+              name: name.image,
+              assignments: list,
+            } as const;
+          case 'generator':
+            return {
+              type: 'generator',
+              name: name.image,
+              assignments: list,
+            } as const;
+          case 'model':
+            return {
+              type: 'model',
+              name: name.image,
+              properties: list,
+            } as const;
+          case 'view':
+            return {
+              type: 'view',
+              name: name.image,
+              properties: list,
+            } as const;
+          case 'enum':
+            return {
+              type: 'enum',
+              name: name.image,
+              enumerators: list,
+            } as const;
+          default:
+            throw new Error(`Unexpected block type: ${type}`);
+        }
+      })();
 
-  break(): Types.Break {
-    return { type: 'break' };
-  }
-
-  comment(ctx: CstNode & { text: [IToken] }): Types.Comment {
-    const [comment] = ctx.text;
-    const data = { type: 'comment', text: comment.image } as const;
-    return appendLocationData(data, comment);
-  }
-
-  block(ctx: CstNode & { list: CstNode[] }): Types.Block[] {
-    return ctx.list?.map((item) => this.visit([item]));
-  }
-
-  assignment(
-    ctx: CstNode & { assignmentName: [IToken]; assignmentValue: [CstNode] }
-  ): Types.Assignment {
-    const value = this.visit(ctx.assignmentValue);
-    const [key] = ctx.assignmentName;
-    const data = { type: 'assignment', key: key.image, value } as const;
-    return appendLocationData(data, key);
-  }
-
-  field(
-    ctx: CstNode & {
-      fieldName: [IToken];
-      fieldType: [CstNode];
-      array: [IToken];
-      optional: [IToken];
-      attributeList: CstNode[];
-      comment: [IToken];
+      return this.maybeAppendLocationData(data, type, name);
     }
-  ): Types.Field {
-    const fieldType = this.visit(ctx.fieldType);
-    const [name] = ctx.fieldName;
-    const attributes =
-      ctx.attributeList && ctx.attributeList.map((item) => this.visit([item]));
-    const comment = ctx.comment?.[0]?.image;
-    const data = {
-      type: 'field',
-      name: name.image,
-      fieldType,
-      array: ctx.array != null,
-      optional: ctx.optional != null,
-      attributes,
-      comment,
-    } as const;
 
-    return appendLocationData(data, name, ctx.optional?.[0], ctx.array?.[0]);
-  }
-
-  attribute(
-    ctx: CstNode & {
-      blockAttribute: [IToken];
-      fieldAttribute: [IToken];
-      groupName: [IToken];
-      attributeName: [IToken];
-      attributeArg: CstNode[];
+    break(): Types.Break {
+      return { type: 'break' };
     }
-  ): Types.Attr {
-    const [name] = ctx.attributeName;
-    const [group] = ctx.groupName || [{}];
-    const args =
-      ctx.attributeArg && ctx.attributeArg.map((attr) => this.visit(attr));
-    const kind = ctx.blockAttribute != null ? 'object' : 'field';
-    const data = {
-      type: 'attribute',
-      name: name.image,
-      kind,
-      group: group.image,
-      args,
-    } as const;
-    const attrs = kind === 'object' ? ctx.blockAttribute : ctx.fieldAttribute;
-    return appendLocationData(data, name, ...attrs, group);
-  }
 
-  attributeArg(ctx: CstNode & { value: [CstNode] }): Types.AttributeArgument {
-    const value = this.visit(ctx.value);
-    return { type: 'attributeArgument', value };
-  }
-
-  func(
-    ctx: CstNode & { funcName: [IToken]; value: CstNode[]; keyedArg: CstNode[] }
-  ): Types.Func {
-    const [name] = ctx.funcName;
-    const params = ctx.value && ctx.value.map((item) => this.visit([item]));
-    const keyedParams =
-      ctx.keyedArg && ctx.keyedArg.map((item) => this.visit([item]));
-    const pars = (params || keyedParams) && [
-      ...(params ?? []),
-      ...(keyedParams ?? []),
-    ];
-    const data = { type: 'function', name: name.image, params: pars } as const;
-    return appendLocationData(data, name);
-  }
-
-  array(ctx: CstNode & { value: CstNode[] }): Types.RelationArray {
-    const args = ctx.value && ctx.value.map((item) => this.visit([item]));
-    return { type: 'array', args };
-  }
-
-  keyedArg(
-    ctx: CstNode & { keyName: [IToken]; value: [CstNode] }
-  ): Types.KeyValue {
-    const [key] = ctx.keyName;
-    const value = this.visit(ctx.value);
-    const data = { type: 'keyValue', key: key.image, value } as const;
-    return appendLocationData(data, key);
-  }
-
-  value(ctx: CstNode & { value: [IToken] | [CstNode] }): Types.Value {
-    if (isToken(ctx.value)) {
-      const [{ image }] = ctx.value;
-      return image;
+    comment(ctx: CstNode & { text: [IToken] }): Types.Comment {
+      const [comment] = ctx.text;
+      const data = { type: 'comment', text: comment.image } as const;
+      return this.maybeAppendLocationData(data, comment);
     }
-    return this.visit(ctx.value);
-  }
 
-  enum(
-    ctx: CstNode & { enumName: [IToken]; comment: [IToken] }
-  ): Types.Enumerator {
-    const [name] = ctx.enumName;
-    const comment = ctx.comment?.[0]?.image;
-    const data = { type: 'enumerator', name: name.image, comment } as const;
-    return appendLocationData(data, name);
-  }
-}
+    block(ctx: CstNode & { list: CstNode[] }): Types.Block[] {
+      return ctx.list?.map((item) => this.visit([item]));
+    }
+
+    assignment(
+      ctx: CstNode & { assignmentName: [IToken]; assignmentValue: [CstNode] }
+    ): Types.Assignment {
+      const value = this.visit(ctx.assignmentValue);
+      const [key] = ctx.assignmentName;
+      const data = { type: 'assignment', key: key.image, value } as const;
+      return this.maybeAppendLocationData(data, key);
+    }
+
+    field(
+      ctx: CstNode & {
+        fieldName: [IToken];
+        fieldType: [CstNode];
+        array: [IToken];
+        optional: [IToken];
+        attributeList: CstNode[];
+        comment: [IToken];
+      }
+    ): Types.Field {
+      const fieldType = this.visit(ctx.fieldType);
+      const [name] = ctx.fieldName;
+      const attributes =
+        ctx.attributeList &&
+        ctx.attributeList.map((item) => this.visit([item]));
+      const comment = ctx.comment?.[0]?.image;
+      const data = {
+        type: 'field',
+        name: name.image,
+        fieldType,
+        array: ctx.array != null,
+        optional: ctx.optional != null,
+        attributes,
+        comment,
+      } as const;
+
+      return this.maybeAppendLocationData(
+        data,
+        name,
+        ctx.optional?.[0],
+        ctx.array?.[0]
+      );
+    }
+
+    attribute(
+      ctx: CstNode & {
+        blockAttribute: [IToken];
+        fieldAttribute: [IToken];
+        groupName: [IToken];
+        attributeName: [IToken];
+        attributeArg: CstNode[];
+      }
+    ): Types.Attr {
+      const [name] = ctx.attributeName;
+      const [group] = ctx.groupName || [{}];
+      const args =
+        ctx.attributeArg && ctx.attributeArg.map((attr) => this.visit(attr));
+      const kind = ctx.blockAttribute != null ? 'object' : 'field';
+      const data = {
+        type: 'attribute',
+        name: name.image,
+        kind,
+        group: group.image,
+        args,
+      } as const;
+      const attrs = kind === 'object' ? ctx.blockAttribute : ctx.fieldAttribute;
+      return this.maybeAppendLocationData(data, name, ...attrs, group);
+    }
+
+    attributeArg(ctx: CstNode & { value: [CstNode] }): Types.AttributeArgument {
+      const value = this.visit(ctx.value);
+      return { type: 'attributeArgument', value };
+    }
+
+    func(
+      ctx: CstNode & {
+        funcName: [IToken];
+        value: CstNode[];
+        keyedArg: CstNode[];
+      }
+    ): Types.Func {
+      const [name] = ctx.funcName;
+      const params = ctx.value && ctx.value.map((item) => this.visit([item]));
+      const keyedParams =
+        ctx.keyedArg && ctx.keyedArg.map((item) => this.visit([item]));
+      const pars = (params || keyedParams) && [
+        ...(params ?? []),
+        ...(keyedParams ?? []),
+      ];
+      const data = {
+        type: 'function',
+        name: name.image,
+        params: pars,
+      } as const;
+      return this.maybeAppendLocationData(data, name);
+    }
+
+    array(ctx: CstNode & { value: CstNode[] }): Types.RelationArray {
+      const args = ctx.value && ctx.value.map((item) => this.visit([item]));
+      return { type: 'array', args };
+    }
+
+    keyedArg(
+      ctx: CstNode & { keyName: [IToken]; value: [CstNode] }
+    ): Types.KeyValue {
+      const [key] = ctx.keyName;
+      const value = this.visit(ctx.value);
+      const data = { type: 'keyValue', key: key.image, value } as const;
+      return this.maybeAppendLocationData(data, key);
+    }
+
+    value(ctx: CstNode & { value: [IToken] | [CstNode] }): Types.Value {
+      if (isToken(ctx.value)) {
+        const [{ image }] = ctx.value;
+        return image;
+      }
+      return this.visit(ctx.value);
+    }
+
+    enum(
+      ctx: CstNode & { enumName: [IToken]; comment: [IToken] }
+    ): Types.Enumerator {
+      const [name] = ctx.enumName;
+      const comment = ctx.comment?.[0]?.image;
+      const data = { type: 'enumerator', name: name.image, comment } as const;
+      return this.maybeAppendLocationData(data, name);
+    }
+
+    maybeAppendLocationData<T extends Record<string, unknown>>(
+      data: T,
+      ...tokens: IToken[]
+    ): T {
+      if (this.config.parser.nodeLocationTracking === 'none') return data;
+      return appendLocationData(data, ...tokens);
+    }
+  };
+};

--- a/test/getSchema.test.ts
+++ b/test/getSchema.test.ts
@@ -14,61 +14,69 @@ describe('getSchema', () => {
   }
 
   describe('with location tracking', () => {
-    beforeAll(() => {
-      getConfig().parser.nodeLocationTracking = 'full';
-    });
+    describe('passed-in config', () => {
+      it('contains field location info', async () => {
+        const source = await loadFixture('example.prisma');
+        const components = getSchema(source, {
+          parser: {
+            nodeLocationTracking: 'full',
+          },
+        });
+        const field = getField();
+        expect(field).toHaveProperty('location.startLine', 14);
+        expect(field).toHaveProperty('location.startColumn', 3);
+        // TODO: these offsets are OS-specific, due to the differing length of the line endings
+        expect(field).toHaveProperty('location.startOffset');
+        expect(field).toHaveProperty('location.endLine', 14);
+        expect(field).toHaveProperty('location.endColumn', 4);
+        expect(field).toHaveProperty('location.endOffset');
 
-    afterAll(() => {
-      getConfig().parser.nodeLocationTracking = 'none';
-    });
-
-    it('contains field location info', async () => {
-      const source = await loadFixture('example.prisma');
-      const components = getSchema(source);
-      const field = getField();
-      expect(field).toHaveProperty('location.startLine', 14);
-      expect(field).toHaveProperty('location.startColumn', 3);
-      // TODO: these offsets are OS-specific, due to the differing length of the line endings
-      expect(field).toHaveProperty('location.startOffset');
-      expect(field).toHaveProperty('location.endLine', 14);
-      expect(field).toHaveProperty('location.endColumn', 4);
-      expect(field).toHaveProperty('location.endOffset');
-
-      function getField(): Field | null {
-        for (const component of components.list) {
-          if (component.type === 'model') {
-            const field = component.properties.find(
-              (field) => field.type === 'field'
-            ) as Field;
-            if (field) return field;
+        function getField(): Field | null {
+          for (const component of components.list) {
+            if (component.type === 'model') {
+              const field = component.properties.find(
+                (field) => field.type === 'field'
+              ) as Field;
+              if (field) return field;
+            }
           }
+          return null;
         }
-        return null;
-      }
+      });
     });
 
-    it('contains block attribute location info', async () => {
-      const source = await loadFixture('example.prisma');
-      const components = getSchema(source);
-      const attr = getBlockAttribute();
-      expect(attr).toHaveProperty('location.startLine', 37);
-      expect(attr).toHaveProperty('location.startColumn', 3);
-      expect(attr).toHaveProperty('location.startOffset');
-      expect(attr).toHaveProperty('location.endLine', 37);
-      expect(attr).toHaveProperty('location.endColumn', 7);
-      expect(attr).toHaveProperty('location.endOffset');
+    describe('static config', () => {
+      beforeAll(() => {
+        getConfig().parser.nodeLocationTracking = 'full';
+      });
 
-      function getBlockAttribute(): BlockAttribute | null {
-        for (const component of components.list) {
-          if (component.type === 'model' && component.name === 'Post') {
-            const attr = component.properties.find(
-              (attr) => attr.type === 'attribute'
-            );
-            if (attr) return attr as BlockAttribute;
+      afterAll(() => {
+        getConfig().parser.nodeLocationTracking = 'none';
+      });
+
+      it('contains block attribute location info', async () => {
+        const source = await loadFixture('example.prisma');
+        const components = getSchema(source);
+        const attr = getBlockAttribute();
+        expect(attr).toHaveProperty('location.startLine', 37);
+        expect(attr).toHaveProperty('location.startColumn', 3);
+        expect(attr).toHaveProperty('location.startOffset');
+        expect(attr).toHaveProperty('location.endLine', 37);
+        expect(attr).toHaveProperty('location.endColumn', 7);
+        expect(attr).toHaveProperty('location.endOffset');
+
+        function getBlockAttribute(): BlockAttribute | null {
+          for (const component of components.list) {
+            if (component.type === 'model' && component.name === 'Post') {
+              const attr = component.properties.find(
+                (attr) => attr.type === 'attribute'
+              );
+              if (attr) return attr as BlockAttribute;
+            }
           }
+          return null;
         }
-        return null;
-      }
+      });
     });
   });
 


### PR DESCRIPTION
I finally got around to hacking on using location data `prisma-lint`!

https://github.com/loop-payments/prisma-lint/pull/84

Everything worked great when testing in the `prisma-lint` repository, but I didn't get location infomration when running on a different repository (`backend`) that uses `prisma-lint`. I wasn't sure how to get the location node configuration for `prisma-ast` to be set by `prisma-lint` without requiring `backend` to also have to configure `prisma-ast`, which felt like too much to ask for users of `prisma-lint`.

This PR allows `prisma-lint` to request location information on demand from `prisma-ast`, regardless of the config.